### PR TITLE
MAS-193 max word count

### DIFF
--- a/cms/models/Item.js
+++ b/cms/models/Item.js
@@ -47,7 +47,7 @@ Item.add({
 		type: Types.Textarea,
 		required: false,
 		initial: false,
-		max: 280,
+		max: 281,
 		label: "Short summary"
 	},
 	publicationDate: {


### PR DESCRIPTION
In keystone the value entered for max is not inclusive - if you set it to 60, it will allow anything less than 60 but not 60 (https://github.com/keystonejs/keystone-classic/blob/d34f45662eb359e2cb18b397f2ffea21f9883141/fields/types/text/TextType.js#L26)