### PR TITLE
MAS-000 Hotfix - Hardcode image URLs

### DIFF
--- a/mailchimp-templates/daily.html
+++ b/mailchimp-templates/daily.html
@@ -3199,7 +3199,7 @@
                               <tr>
                                 <td class="top-logo">
                                   <img
-                                    src="#{AWS:StaticURL}email/nice-logo-mobile.png"
+                                    src="https://www.medicinesresources.nhs.uk/email/nice-logo-mobile.png"
                                     class="float-left"
                                     alt="NICE logo"
                                     align="left"
@@ -3207,7 +3207,7 @@
                                 </td>
                                 <td class="top-logo">
                                   <img
-                                    src="#{AWS:StaticURL}email/sps-logo.png"
+                                    src="https://www.medicinesresources.nhs.uk/email/sps-logo.png"
                                     class="float-right"
                                     alt="SPS logo"
                                     align="right"

--- a/mailchimp-templates/weekly.html
+++ b/mailchimp-templates/weekly.html
@@ -3206,7 +3206,7 @@
                               <tr>
                                 <td class="top-logo">
                                   <img
-                                    src="#{AWS:StaticURL}email/nice-logo-mobile.png"
+                                    src="https://www.medicinesresources.nhs.uk/email/nice-logo-mobile.png"
                                     class="float-left"
                                     alt="NICE logo"
                                     align="left"
@@ -3214,7 +3214,7 @@
                                 </td>
                                 <td class="top-logo">
                                   <img
-                                    src="#{AWS:StaticURL}email/sps-logo.png"
+                                    src="https://www.medicinesresources.nhs.uk/email/sps-logo.png"
                                     class="float-right"
                                     alt="SPS logo"
                                     align="right"


### PR DESCRIPTION
In mailchimp template, image source is at some point getting mangled from this 
`src="#{AWS:StaticURL}email/nice-logo-mobile.png"`
into 
`src="#%7BAWS:StaticURL%7Demail/nice-logo-mobile.png"`
and I can't work out why. Hardcoding the image URLs for the next few days.